### PR TITLE
Update requirements.txt to use updated version of the crypto library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ malduck==4.1.0
 python-magic==0.4.22
 Flask==1.1.2
 unicorn==1.0.2
-pycrypto==2.6.1
+pycryptodome
 requests==2.25.1


### PR DESCRIPTION
The pycryto library used in the requirements.txt file has been deprecated for about 9 years and contains security vulnerabilites. Pycrytodome is up to date and should be a drop in replacement from what I've seen it used for the code.